### PR TITLE
Implement rdefer which runs in reverse order, matching Go's behaviour

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         }
     ],
     "autoload": {
+        "psr-4": {
+            "PhpDefer\\": "src/"
+        },
         "files": ["src/functions.inc.php"]
     },
     "autoload-dev": {

--- a/src/Deferable.php
+++ b/src/Deferable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PhpDefer;
+
+interface Deferable
+{
+    /**
+     * Append a deferable to the deepest available child.
+     *
+     * @param Deferable $deferable
+     */
+    public function append(Deferable $deferable);
+}

--- a/tests/ReverseDeferTest.php
+++ b/tests/ReverseDeferTest.php
@@ -1,0 +1,145 @@
+<?php
+
+
+/*
+ * This file is part of the php-defer/php-defer package.
+ *
+ * (c) Bartłomiej Krukowski <bartlomiej@krukowski.me>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpDefer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \rdefer
+ */
+final class ReverseDeferTest extends TestCase
+{
+    public function testDefer()
+    {
+        $sentence = new Sentence();
+        $this->appendOneTwoThree($sentence);
+        $this->assertSame('one two three', $sentence->getSentence());
+    }
+
+    public function testDeferDeepNested()
+    {
+        $sentence = new Sentence();
+        $this->appendOneTwoThreeFour($sentence);
+        $this->assertSame('one two three four', $sentence->getSentence());
+    }
+
+    public function testThrowException()
+    {
+        $sentence = new Sentence();
+
+        try {
+            $this->throwExceptionInDefer($sentence);
+        } catch (DeferException $e) {
+        }
+
+        $this->assertSame('before exception ... after exception', $sentence->getSentence());
+    }
+
+    public function testMultipleContexts()
+    {
+        $sentence = new Sentence();
+        $this->appendOneTwoThreeInMultipleContexts($sentence);
+        $this->assertSame('one two three', $sentence->getSentence());
+    }
+
+    public function testUnsetContext()
+    {
+        $s1 = new Sentence();
+        $s2 = new Sentence();
+
+        rdefer($ctx1, function () use ($s1) {
+            $s1->append('defer');
+        });
+        rdefer($ctx2, function () use ($s2) {
+            $s2->append('defer');
+        });
+
+        $this->assertSame('', $s1->getSentence());
+        $this->assertSame('', $s2->getSentence());
+
+        unset($ctx2);
+        $this->assertSame('', $s1->getSentence());
+        $this->assertSame('defer', $s2->getSentence());
+    }
+
+    /**
+     * @param Sentence $sentence
+     */
+    private function appendOneTwoThreeInMultipleContexts(Sentence $sentence)
+    {
+        rdefer($ctx1, function () use ($sentence) {
+            $sentence->append('two');
+        });
+
+        rdefer($ctx2, function () use ($sentence) {
+            $sentence->append('three');
+        });
+
+        $sentence->append('one');
+    }
+
+    /**
+     * @param Sentence $sentence
+     */
+    private function appendOneTwoThree(Sentence $sentence)
+    {
+        rdefer($_, function () use ($sentence) {
+            $sentence->append('three');
+        });
+
+        rdefer($_, function () use ($sentence) {
+            $sentence->append('two');
+        });
+
+        $sentence->append('one');
+    }
+
+    /**
+     * @param Sentence $sentence
+     */
+    private function appendOneTwoThreeFour(Sentence $sentence)
+    {
+        rdefer($_, function () use ($sentence) {
+            $sentence->append('four');
+        });
+
+        rdefer($_, function () use ($sentence) {
+            $sentence->append('three');
+        });
+
+        rdefer($_, function () use ($sentence) {
+            $sentence->append('two');
+        });
+
+        $sentence->append('one');
+    }
+
+    /**
+     * @param Sentence $sentence
+     *
+     * @throws DeferException
+     */
+    private function throwExceptionInDefer(Sentence $sentence)
+    {
+        rdefer($_, function () use ($sentence) {
+            $sentence->append('after exception');
+        });
+
+        $sentence->append('before exception');
+        $sentence->append('...');
+
+        throw new DeferException();
+    }
+}


### PR DESCRIPTION
Add an alternate implementation which runs in reverse order of the current implementation, which is more correct to how Go executes it.

I mainly just wrote this as a proof-of-concept, maybe this lib doesn't need this. But maybe you'd want to replace the existing implementation with this one? Up to you.