### PR TITLE
Feature - LIFO Execution Order (Matching Go's Behavior)

### DIFF
--- a/src/functions.inc.php
+++ b/src/functions.inc.php
@@ -10,22 +10,26 @@
  */
 
 /**
- * @param null|array $context
- * @param callable   $callback
+ * @param null|SplStack $context
+ * @param callable      $callback
  */
-function defer(?array &$context, callable $callback)
+function defer(?SplStack &$context, callable $callback)
 {
-    $context[] = new class($callback) {
-        private $callback;
+    $context = $context ?? new SplStack();
 
-        public function __construct($callback)
-        {
-            $this->callback = $callback;
-        }
+    $context->push(
+        new class($callback) {
+            private $callback;
 
-        public function __destruct()
-        {
-            \call_user_func($this->callback);
+            public function __construct($callback)
+            {
+                $this->callback = $callback;
+            }
+
+            public function __destruct()
+            {
+                \call_user_func($this->callback);
+            }
         }
-    };
+    );
 }

--- a/tests/DeferTest.php
+++ b/tests/DeferTest.php
@@ -24,7 +24,7 @@ final class DeferTest extends TestCase
     {
         $sentence = new Sentence();
         $this->appendOneTwoThree($sentence);
-        $this->assertSame('one three two', $sentence->getSentence());
+        $this->assertSame('one two three', $sentence->getSentence());
     }
 
     public function testThrowException()
@@ -88,10 +88,10 @@ final class DeferTest extends TestCase
     private function appendOneTwoThree(Sentence $sentence)
     {
         defer($_, function () use ($sentence) {
-            $sentence->append('two');
+            $sentence->append('three');
         });
         defer($_, function () use ($sentence) {
-            $sentence->append('three');
+            $sentence->append('two');
         });
 
         $sentence->append('one');

--- a/tests/DeferTest.php
+++ b/tests/DeferTest.php
@@ -24,7 +24,7 @@ final class DeferTest extends TestCase
     {
         $sentence = new Sentence();
         $this->appendOneTwoThree($sentence);
-        $this->assertSame('one two three', $sentence->getSentence());
+        $this->assertSame('one three two', $sentence->getSentence());
     }
 
     public function testThrowException()


### PR DESCRIPTION
# Scope

This PR is a re-implementation of #2, with the differences being that:

 - It changes the default implementation (rather than providing an alternative) to match Go's behavior of LIFO execution order.
 - It uses [the built-in `SplStack` data-structure](https://www.php.net/manual/en/class.splstack.php) for the internal stacking context implementation.

# Credit

Credit goes to @francislavoie for this idea, in which this implementation was based off-of! He even encouraged me to contribute via my own PR (https://github.com/php-defer/php-defer/pull/2#issuecomment-540227965). Thanks!