### PR TITLE
Feature - Add `go_defer` function to mirror Golang's LIFO defer behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,22 @@ A [defer statement](https://blog.golang.org/defer-panic-and-recover) originally 
 <?php
 
 defer($context, $callback);
+
+go_defer($context, $callback);
 ```
 
-`defer` requires two parameters: `$context` and `$callback`.
+`defer` and `go_defer` require two parameters: `$context` and `$callback`.
 
 1. `$context` - unused in your app, required to achieve "defer" effect. I recommend to use `$_` always.
 2. `$callback` - a callback which is executed after the surrounding function returns.
 
+`defer` executes callbacks First In, First Out. Functions execute in the order you deferred them.
+
+`go_defer` more accurately emulates Golang's `defer` functionality and executes callbacks in Last In, First Out order.
+
 ## Examples
 
-### Defer the execution of a code
+### Defer the execution of a code, using `defer`
 
 ```php
 <?php
@@ -49,6 +55,37 @@ echo "after goodbye\n";
 // ...
 // goodbye
 // after goodbye
+```
+
+### Defer the execution of a code, using `go_defer`
+
+```php
+<?php
+
+function rollCall()
+{
+    go_defer($_, function () {
+        echo "I was deferred first!\n";
+    });
+    
+    go_defer($_, function () {
+        echo "I was deferred last!\n";
+    });
+
+    echo "I was NOT deferred!\n";
+}
+
+echo "before rollCall\n";
+rollCall();
+echo "after rollCall\n";
+
+// Output:
+//
+// before rollCall
+// I was NOT deferred!
+// I was deferred last!
+// I was deferred first!
+// after rollCall
 ```
 
 ### Defer and exceptions

--- a/src/functions.inc.php
+++ b/src/functions.inc.php
@@ -29,3 +29,25 @@ function defer(?array &$context, callable $callback)
         }
     };
 }
+
+/**
+ * @param null|array $context
+ * @param callable   $callback
+ */
+function go_defer(?array &$context, callable $callback)
+{
+    $context = $context ?? [];
+    array_unshift($context, new class($callback) {
+        private $callback;
+
+        public function __construct($callback)
+        {
+            $this->callback = $callback;
+        }
+
+        public function __destruct()
+        {
+            \call_user_func($this->callback);
+        }
+    });
+}

--- a/tests/GoDeferTest.php
+++ b/tests/GoDeferTest.php
@@ -39,13 +39,6 @@ final class GoDeferTest extends TestCase
         $this->assertSame('before exception ... after exception', $sentence->getSentence());
     }
 
-    public function testMultipleContexts()
-    {
-        $sentence = new Sentence();
-        $this->appendOneTwoThreeInMultipleContexts($sentence);
-        $this->assertSame('one two three', $sentence->getSentence());
-    }
-
     public function testUnsetContext()
     {
         $s1 = new Sentence();
@@ -64,22 +57,6 @@ final class GoDeferTest extends TestCase
         unset($ctx2);
         $this->assertSame('', $s1->getSentence());
         $this->assertSame('defer', $s2->getSentence());
-    }
-
-    /**
-     * @param Sentence $sentence
-     */
-    private function appendOneTwoThreeInMultipleContexts(Sentence $sentence)
-    {
-        go_defer($ctx1, function () use ($sentence) {
-            $sentence->append('three');
-        });
-
-        go_defer($ctx2, function () use ($sentence) {
-            $sentence->append('two');
-        });
-
-        $sentence->append('one');
     }
 
     /**

--- a/tests/GoDeferTest.php
+++ b/tests/GoDeferTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the php-defer/php-defer package.
+ *
+ * (c) Bartłomiej Krukowski <bartlomiej@krukowski.me>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpDefer;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ *
+ * @covers \defer
+ */
+final class GoDeferTest extends TestCase
+{
+    public function testDefer()
+    {
+        $sentence = new Sentence();
+        $this->appendOneTwoThree($sentence);
+        $this->assertSame('one two three', $sentence->getSentence());
+    }
+
+    public function testThrowException()
+    {
+        $sentence = new Sentence();
+
+        try {
+            $this->throwExceptionInDefer($sentence);
+        } catch (DeferException $e) {
+        }
+
+        $this->assertSame('before exception ... after exception', $sentence->getSentence());
+    }
+
+    public function testMultipleContexts()
+    {
+        $sentence = new Sentence();
+        $this->appendOneTwoThreeInMultipleContexts($sentence);
+        $this->assertSame('one two three', $sentence->getSentence());
+    }
+
+    public function testUnsetContext()
+    {
+        $s1 = new Sentence();
+        $s2 = new Sentence();
+
+        go_defer($ctx2, function () use ($s2) {
+            $s2->append('defer');
+        });
+        go_defer($ctx1, function () use ($s1) {
+            $s1->append('defer');
+        });
+
+        $this->assertSame('', $s1->getSentence());
+        $this->assertSame('', $s2->getSentence());
+
+        unset($ctx2);
+        $this->assertSame('', $s1->getSentence());
+        $this->assertSame('defer', $s2->getSentence());
+    }
+
+    /**
+     * @param Sentence $sentence
+     */
+    private function appendOneTwoThreeInMultipleContexts(Sentence $sentence)
+    {
+        go_defer($ctx1, function () use ($sentence) {
+            $sentence->append('three');
+        });
+
+        go_defer($ctx2, function () use ($sentence) {
+            $sentence->append('two');
+        });
+
+        $sentence->append('one');
+    }
+
+    /**
+     * @param Sentence $sentence
+     */
+    private function appendOneTwoThree(Sentence $sentence)
+    {
+        go_defer($_, function () use ($sentence) {
+            $sentence->append('three');
+        });
+
+        go_defer($_, function () use ($sentence) {
+            $sentence->append('two');
+        });
+
+        $sentence->append('one');
+    }
+
+    /**
+     * @param Sentence $sentence
+     *
+     * @throws DeferException
+     */
+    private function throwExceptionInDefer(Sentence $sentence)
+    {
+        go_defer($_, function () use ($sentence) {
+            $sentence->append('after exception');
+        });
+
+        $sentence->append('before exception');
+        $sentence->append('...');
+
+        throw new DeferException();
+    }
+}


### PR DESCRIPTION
Similar to the implementation of #3, and the idea of providing an alternative instead of a replacement in #2. Implementation was drafted prior to my knowledge of these existing PR's.

This implementation in no way alters or changes the original `defer` function provided. This was mostly an academic exercise rather than an effort to assert a correct ordering or to specifically match Golang's specification.

My derivative is an optional second function, `go_defer`, to allow the proper FIFO/LIFO implementation choice up to the user. It comes with its own rewritten copy of the Tests, and an updated README to explain and accommodate examples for both functions.
